### PR TITLE
Upgrade Actions versions

### DIFF
--- a/.github/workflows/commit-linting.yml
+++ b/.github/workflows/commit-linting.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         ref: main
         fetch-depth: 1
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version: '1.23.x'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54
+          version: v1.62
 
           # Optional: working directory, useful for monorepos
           #working-directory: v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.19.x", "1.20.x", "1.21.x", "1.22.x" ]
+        go-version: [ "1.22.x", "1.23.x" ]
         #os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
Dependency upgrades have been failing because aws-sdk-go-v2 requires a newer Golang (reasonably so) so let's upgrade everything