### PR TITLE
Touch up doc comments

### DIFF
--- a/backender.go
+++ b/backender.go
@@ -6,7 +6,7 @@ import (
 )
 
 // StorageBackender defines the contract expected of a Storage Backend for the
-// cicruit breaker in use.
+// [CircuitBreaker] to use to store information.
 type StorageBackender interface {
 	// Store the circuit information for the given string name
 	Store(context.Context, string, CircuitInformation) error
@@ -17,8 +17,8 @@ type StorageBackender interface {
 	Lock(context.Context, string) (sync.Locker, error)
 }
 
-// WithStorageBackend allows the user to specify a StorageBackender
-// implementation for CircuitBreakers
+// WithStorageBackend allows the user to specify a [StorageBackender]
+// implementation for [CircuitBreaker]s.
 func WithStorageBackend(backend StorageBackender) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.StorageBackend != nil {

--- a/backends/dynamodb/dynamodb.go
+++ b/backends/dynamodb/dynamodb.go
@@ -39,7 +39,7 @@ type DynamoLock struct {
 	lock      *ddblock.Lock
 }
 
-// Lock does nothing as the lock has alrady been acquired at this point
+// Lock does nothing as the lock has already been acquired at this point
 func (l *DynamoLock) Lock() {}
 
 // Unlock releases the backend lock

--- a/backends/in_memory.go
+++ b/backends/in_memory.go
@@ -12,14 +12,15 @@ type infoWithLock struct {
 	lock        *sync.Mutex
 }
 
-// InMemoryBackend defines an in memory backend designed to be used primarily
-// for proofs of concept and testing
+// InMemoryBackend defines an in
+// [github.com/sigmavirus24/circuitry>StorageBackender] backend designed to be
+// used primarily for proofs of concept and testing
 type InMemoryBackend struct {
 	information map[string]infoWithLock
 	lock        sync.Mutex
 }
 
-// NewInMemoryBackend creates a new in memory storage backend
+// NewInMemoryBackend creates a new [InMemoryBackend]
 func NewInMemoryBackend() circuitry.StorageBackender {
 	return &InMemoryBackend{
 		information: make(map[string]infoWithLock),

--- a/backends/in_memory.go
+++ b/backends/in_memory.go
@@ -13,7 +13,7 @@ type infoWithLock struct {
 }
 
 // InMemoryBackend defines an in
-// [github.com/sigmavirus24/circuitry>StorageBackender] backend designed to be
+// [github.com/sigmavirus24/circuitry.StorageBackender] backend designed to be
 // used primarily for proofs of concept and testing
 type InMemoryBackend struct {
 	information map[string]infoWithLock

--- a/backends/redis/redis.go
+++ b/backends/redis/redis.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bsm/redislock"
 	redis "github.com/redis/go-redis/v9"
+
 	"github.com/sigmavirus24/circuitry"
 )
 
@@ -36,7 +37,7 @@ func (l *redLock) Lock()   {}
 func (l *redLock) Unlock() { _ = l.lock.Release(l.ctx) }
 
 // Backend implements the StorageBackender interface for Redis using
-// redis/go-redis/v9 and bsm/redislock
+// [github.com/redis/go-redis/v9] and [github.com/bsm/redislock]
 type Backend struct {
 	Client         Client
 	Locker         Locker
@@ -57,7 +58,7 @@ func (c *Backend) Store(ctx context.Context, name string, ci circuitry.CircuitIn
 
 // Retrieve looks up the key in Redis and returns the value after
 // deserializing it from JSON. If the key is not present in Redis, this will
-// return an empty circuitry.CircuitInformation
+// return an empty [github.com/sigmavirus24/circuitry.CircuitInformation].
 func (c *Backend) Retrieve(ctx context.Context, name string) (circuitry.CircuitInformation, error) {
 	jsonCI, err := c.Client.Get(ctx, name).Result()
 	ci := circuitry.CircuitInformation{}

--- a/circuitry.go
+++ b/circuitry.go
@@ -10,7 +10,7 @@ import (
 )
 
 // WorkFn defines the allowed interface of a function that can be passed to
-// Execute
+// [CircuitBreaker].Execute.
 type WorkFn func() (any, error)
 
 // CircuitBreaker defines the interface for an implementation of a circuit
@@ -256,19 +256,19 @@ func (cb *circuitBreaker) State(ctx context.Context) (CircuitState, error) {
 
 var _ CircuitBreaker = (*circuitBreaker)(nil)
 
-// CircuitBreakerFactory creates CircuitBreakers for a given named circuit
+// CircuitBreakerFactory creates [CircuitBreaker]s for a given named circuit
 type CircuitBreakerFactory struct {
 	settings *FactorySettings
 }
 
-// NewCircuitBreakerFactory builds a new CircuitBreakerFactory from
-// FactorySettings supplied
+// NewCircuitBreakerFactory builds a new [CircuitBreakerFactory] from
+// the [FactorySettings] supplied
 func NewCircuitBreakerFactory(s *FactorySettings) *CircuitBreakerFactory {
 	return &CircuitBreakerFactory{s}
 }
 
-// BreakerFor builds a new CircuitBreaker for the given named circuit and
-// includes the circuit breaker contxt provided. The context is passed into
+// BreakerFor builds a new [CircuitBreaker] for the given named circuit and
+// includes the circuit breaker context provided. The context is passed into
 // the naming function and can be used by custom naming functions to produce
 // names based off of a template
 func (cbf *CircuitBreakerFactory) BreakerFor(name string, circuitContext map[string]any) CircuitBreaker {

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Package circuitry provides a framework for building distribuited Circuit
+// Package circuitry provides a framework for building distributed Circuit
 // Breakers. It's primarily designed to be able to synchronize state with a
 // backend so that a distributed system can have one Circuit Breaker for any
 // piece it cares to implement that for.
@@ -12,7 +12,7 @@
 // system would have to individually reach your failure threshold to trip the
 // breaker before all instances have stopped talking to it. That could affect
 // availability and performance for your users. Alternatively, you might have
-// ot set the threshold artificially low and risk the breaker opening when it
+// to set the threshold artificially low and risk the breaker opening when it
 // didn't need to.
 //
 // circuitry aims to provide an excellent distributed circuit breaker pattern
@@ -56,7 +56,7 @@
 // # Additional Resources
 //
 // For additional information see also:
-// - https://learn.microsoft.com/en-us/previous-versions/msp-n-p/dn589784(v=pandp.10)?redirectedfrom=MSDN
-// - https://www.redhat.com/architect/circuit-breaker-architecture-pattern
-// - https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/circuit-breaker.html
+//   - https://learn.microsoft.com/en-us/previous-versions/msp-n-p/dn589784(v=pandp.10)?redirectedfrom=MSDN
+//   - https://www.redhat.com/architect/circuit-breaker-architecture-pattern
+//   - https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/circuit-breaker.html
 package circuitry

--- a/errors.go
+++ b/errors.go
@@ -94,7 +94,7 @@ var _ error = (*CircuitSpecificSettingsConflictError)(nil)
 
 var (
 	// ErrStorageBackendAlreadySet is returned when the StorageBackend setting
-	// has alredy been configured
+	// has already been configured
 	ErrStorageBackendAlreadySet = newSettingsConflictError("StorageBackend")
 	// ErrFallbackErrorMatcherAlreadySet is returned when the ErrorMatcher setting has
 	// already been configured

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -2,7 +2,8 @@ package log
 
 import "github.com/sirupsen/logrus"
 
-// Logrus implements circuitry's Logger interface using sirupsen/logrus
+// Logrus implements circuitry's [Logger] interface using
+// [github.com/sirupsen/logrus]
 type Logrus struct {
 	l logrus.FieldLogger
 }

--- a/log/noop.go
+++ b/log/noop.go
@@ -1,6 +1,6 @@
 package log
 
-// NoOp implements a no-op version of the  interface as a
+// NoOp implements a no-op version of the interface as a
 // reasonable default for circuitry to use
 type NoOp struct{}
 

--- a/log/slog.go
+++ b/log/slog.go
@@ -1,7 +1,3 @@
-//go:build go1.21
-
-// +bulid go1.21
-
 package log
 
 import "log/slog"

--- a/log/slog_test.go
+++ b/log/slog_test.go
@@ -1,6 +1,3 @@
-//go:build go1.21
-
-// +bulid go1.21
 package log_test
 
 import (

--- a/settings.go
+++ b/settings.go
@@ -15,19 +15,19 @@ type NameFunc func(circuit string, circuitContext map[string]any) string
 // considered to be failed
 type ExpectedErrorMatcherFunc func(err error) ExecutionStatus
 
-// WillTripFunc defines the signature of a function that allows the user to define
-// when a CircuitBreaker may trip. It accepts the name of the CircuitBreaker,
-// the value of the FailureCountThreshold from the FactorySetings, and the
-// information about the state of the circuit. It returns `true` if the CircuitBreaker
-// should transition to `CircuitOpen`
+// WillTripFunc defines the signature of a function that allows the user to
+// define when a [CircuitBreaker] may trip. It accepts the name of the
+// [CircuitBreaker], the value of the FailureCountThreshold from the
+// [FactorySettings], and the information about the state of the circuit. It
+// returns `true` if the [CircuitBreaker] should transition to [CircuitOpen]
 type WillTripFunc func(name string, configuredThreshold uint64, information CircuitInformation) bool
 
 // StateChangeFunc defines the signature of a function that allows the user to
-// define custome logic around the changing of CircuitBreaker state.
+// define custom logic around the changing of [CircuitBreaker] state.
 type StateChangeFunc func(name string, circuitContext map[string]any, from, to CircuitState)
 
 // DefaultNameFunc is a default name implementation that simply uses the name of
-// te circuit for the name of a given circuit breaker
+// the circuit for the name of a given circuit breaker
 func DefaultNameFunc(circuit string, circuitContext map[string]any) string {
 	return circuit
 }
@@ -52,51 +52,30 @@ func DefaultErrorMatcher(err error) ExecutionStatus {
 }
 
 // DefaultTripFunc is the default function used to determine if a
-// CircuitBreaker is ready to trip. By default this returns true if the number
-// of ConsecutiveFailures is greater than the FailureCountThreshold
+// [CircuitBreaker] is ready to trip. By default this returns true if the number
+// of [CircuitInformation].ConsecutiveFailures is greater than the
+// [FactorySettings].FailureCountThreshold.
 func DefaultTripFunc(_ string, configuredThreshold uint64, information CircuitInformation) bool {
 	return information.ConsecutiveFailures > configuredThreshold
 }
 
 // FactorySettings contains information for configuring a CircuitBreakerFactory and
-// any CircuitBreaker it creates. The settings are:
-//   - `StorageBackend` which allows for remote storage of circuit breaker state
-//   - `NameFn` which allows the CircuitBreakerFactory to dynamically generate
-//     names
-//   - `FallbackErrorMatcher` which provides for a default error matcher if one
-//     isn't found for a specific CircuitBreaker by name
-//   - `CircuitSpecificErrorMatcher` which provides a way for different
-//     CircuitBreakers to have specific error matchers
-//   - `FailureCountThreshold` defines the threshold after which a
-//     CircuitBreaker transitions to the CircuitOpen CircuitState
-//   - `CloseThreshold` defines the number of requests after which a
-//     CircuitBreaker in the CircuitHalfOpen state returns to the
-//     CircuitClosed state.
-//   - `AllowAfter` defines the time after which a CircuitBreaker in the
-//     `CircuitOpen` CircuitState transitions to the `CircuitHalfOpen`
-//     CircuitState. If not specified, the default is 60 seconds.
-//   - `CyclicClearAfter` defines the time after which a CircuitBreaker resets
-//     its internal counts. If not specified, the CircuitBreaker never resets
-//     its internal counts.
-//   - `StateChangeCallback` provides a way to learn when the CircuitBreaker
-//     state is changing.
-//   - `WillTripCircuit` provides a way to customize whether the
-//     CircuitBreaker will trip beyond the failure counts configured
+// any CircuitBreaker it creates.
 type FactorySettings struct {
-	StorageBackend              StorageBackender
-	NameFn                      NameFunc
-	FallbackErrorMatcher        ExpectedErrorMatcherFunc
-	CircuitSpecificErrorMatcher map[string]ExpectedErrorMatcherFunc
-	FailureCountThreshold       uint64
-	CloseThreshold              uint64
-	AllowAfter                  time.Duration
-	CyclicClearAfter            time.Duration
-	StateChangeCallback         StateChangeFunc
-	WillTripCircuit             WillTripFunc
-	Logger                      log.Logger
+	StorageBackend              StorageBackender                    // StorageBackend allows for remote storage of [CircuitBreaker] state.
+	NameFn                      NameFunc                            // NameFn allows the [CircuitBreakerFactory] to dynamically generate names.
+	FallbackErrorMatcher        ExpectedErrorMatcherFunc            // FallbackErrorMatcher which provides for a default error matcher if one isn't found for a specific [CircuitBreaker] by name.
+	CircuitSpecificErrorMatcher map[string]ExpectedErrorMatcherFunc // CircuitSpecificErrorMatcher provides a way for different [CircuitBreaker]s to have specific error matchers.
+	FailureCountThreshold       uint64                              // FailureCountThreshold defines the threshold after which a [CircuitBreaker] transitions to the [CircuitOpen] [CircuitState].
+	CloseThreshold              uint64                              // CloseThreshold defines the number of successful requests after which a [CircuitBreaker] in the [CircuitHalfOpen] [CircuitState] returns to [CircuitClosed] [CircuitState].
+	AllowAfter                  time.Duration                       // AllowAfter defines the time after which a [CircuitBreaker] in the [CircuitOpen] [CircuitState] transitions to [CircuitHalfOpen]. If not specified, the default is 60 seconds.
+	CyclicClearAfter            time.Duration                       // CyclicClearAfter defines the time after which a [CircuitBreaker] resets its internal counts. If not specified, the [CircuitBreaker] never resets its internal counts.
+	StateChangeCallback         StateChangeFunc                     // StateChangeCallback stores a callback for users to learn when the [CircuitBreaker] state is changing.
+	WillTripCircuit             WillTripFunc                        // WillTripCircuit provides a way to customize whether the [WillTripCircuit] will trip in conjunction with the [FailureCountThreshold].
+	Logger                      log.Logger                          // Logger allows the caller to specify a given logger to use for all [CircuitBreaker]s.
 }
 
-// GenerateName builds a name for a CircuitBreaker
+// GenerateName builds a name for a [CircuitBreaker]
 func (s *FactorySettings) GenerateName(circuit string, circuitContext map[string]any) string {
 	if s.NameFn == nil {
 		return DefaultNameFunc(circuit, circuitContext)
@@ -104,7 +83,7 @@ func (s *FactorySettings) GenerateName(circuit string, circuitContext map[string
 	return s.NameFn(circuit, circuitContext)
 }
 
-// circuitBreakerFor builds a CircuitBreaker from the settings configured
+// circuitBreakerFor builds a [CircuitBreaker] from the settings configured
 // globally
 func (s *FactorySettings) circuitBreakerFor(circuit string, circuitContext map[string]any) CircuitBreaker {
 	name := s.GenerateName(circuit, circuitContext)
@@ -140,7 +119,7 @@ func (s *FactorySettings) circuitBreakerFor(circuit string, circuitContext map[s
 	}
 }
 
-// NewFactorySettings constructs a Setings struct with the provided options
+// NewFactorySettings constructs a [FactorySettings] struct with the provided options
 func NewFactorySettings(opts ...SettingsOption) (*FactorySettings, error) {
 	s := &FactorySettings{CircuitSpecificErrorMatcher: make(map[string]ExpectedErrorMatcherFunc), AllowAfter: 0 * time.Second}
 	for _, opt := range opts {
@@ -155,13 +134,14 @@ func NewFactorySettings(opts ...SettingsOption) (*FactorySettings, error) {
 // SettingsOption configures an option on a setting
 type SettingsOption func(s *FactorySettings) error
 
-// WithDefaultFallbackErrorMatcher configures the ErrorMatcher setting a the default
-// value, DefaultErrorMatcher
+// WithDefaultFallbackErrorMatcher configures the FallbackErrorMatcher setting a the default
+// value, [DefaultErrorMatcher]
 func WithDefaultFallbackErrorMatcher() SettingsOption {
 	return WithFallbackErrorMatcher(DefaultErrorMatcher)
 }
 
-// WithFallbackErrorMatcher configures the ErrorMatcher with the provided matcher
+// WithFallbackErrorMatcher configures the FallbackErrorMatcher with the
+// provided matcher.
 func WithFallbackErrorMatcher(matcher ExpectedErrorMatcherFunc) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.FallbackErrorMatcher != nil {
@@ -173,7 +153,7 @@ func WithFallbackErrorMatcher(matcher ExpectedErrorMatcherFunc) SettingsOption {
 }
 
 // WithCircuitSpecificErrorMatcher sets a specific error matcher for a given
-// circuit with the value provided
+// circuit with the value provided.
 func WithCircuitSpecificErrorMatcher(circuitName string, matcher ExpectedErrorMatcherFunc) SettingsOption {
 	return func(s *FactorySettings) error {
 		if _, ok := s.CircuitSpecificErrorMatcher[circuitName]; ok {
@@ -184,13 +164,13 @@ func WithCircuitSpecificErrorMatcher(circuitName string, matcher ExpectedErrorMa
 	}
 }
 
-// WithDefaultNameFunc configure the Name setting a the defualt value,
-// DefaultNameFunc
+// WithDefaultNameFunc configure the NameFn setting with a default value,
+// [DefaultNameFunc].
 func WithDefaultNameFunc() SettingsOption {
 	return WithNameFunc(DefaultNameFunc)
 }
 
-// WithNameFunc configures the Name setting with the provided NameFunc
+// WithNameFunc configures the NameFn setting with the provided [NameFunc].
 func WithNameFunc(namefn NameFunc) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.NameFn != nil {
@@ -202,7 +182,7 @@ func WithNameFunc(namefn NameFunc) SettingsOption {
 }
 
 // WithFailureCountThreshold configures the threshold where the circuit
-// breaker trips to closed
+// breaker trips to [CircuitOpen].
 func WithFailureCountThreshold(threshold uint64) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.FailureCountThreshold > 0 {
@@ -214,7 +194,8 @@ func WithFailureCountThreshold(threshold uint64) SettingsOption {
 }
 
 // WithCloseThreshold configures the number of consecutive successful requests
-// needed for a CircuitHalfOpen to transition to CircuitClosed
+// needed for a [CircuitHalfOpen] [CircuitBreaker] to transition to
+// [CircuitClosed].
 func WithCloseThreshold(threshold uint64) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.CloseThreshold > 0 {
@@ -242,7 +223,7 @@ func WithCyclicClearAfter(duration time.Duration) SettingsOption {
 }
 
 // WithStateChangeCallback configures the StateChangeCallback setting with the
-// provided StateChangeFunc if it's not already set
+// provided [StateChangeFunc] if it's not already set
 func WithStateChangeCallback(cb StateChangeFunc) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.StateChangeCallback != nil {
@@ -254,13 +235,13 @@ func WithStateChangeCallback(cb StateChangeFunc) SettingsOption {
 }
 
 // WithDefaultTripFunc sets the WillTripCircuit setting to the default
-// function `DefaultTripFunc`
+// function [DefaultTripFunc].
 func WithDefaultTripFunc() SettingsOption {
 	return WithTripFunc(DefaultTripFunc)
 }
 
 // WithTripFunc configures the WillTripCircuit setting to have custom logic
-// for when a CircuitBreaker trips open
+// for when a [CircuitBreaker] trips open
 func WithTripFunc(tf WillTripFunc) SettingsOption {
 	return func(s *FactorySettings) error {
 		if s.WillTripCircuit != nil {

--- a/state.go
+++ b/state.go
@@ -9,11 +9,11 @@ import (
 type CircuitState uint32
 
 const (
-	// CircuitClosed describes a closed CircuitBreaker
+	// CircuitClosed describes a closed [CircuitBreaker]
 	CircuitClosed CircuitState = iota
-	// CircuitOpen describes an open CircuitBreaker
+	// CircuitOpen describes an open [CircuitBreaker]
 	CircuitOpen
-	// CircuitHalfOpen describes a half-open CircuitBreaker
+	// CircuitHalfOpen describes a half-open [CircuitBreaker]
 	CircuitHalfOpen
 )
 
@@ -51,8 +51,8 @@ func (es ExecutionStatus) String() string {
 	}
 }
 
-// CircuitInformation describes the full state of a given CircuitBreaker to be
-// for use with a StorageBackender
+// CircuitInformation describes the full state of a given [CircuitBreaker] to be
+// for use with a [StorageBackender]
 type CircuitInformation struct {
 	State                CircuitState `json:"state"`
 	Generation           uint64       `json:"generation"`
@@ -64,7 +64,7 @@ type CircuitInformation struct {
 	ExpiresAfter         time.Time    `json:"expires_after"`
 }
 
-// NewCircuitInformation creates a new CircuitInformation with the state being
+// NewCircuitInformation creates a new [CircuitInformation] with the state being
 // Open and an expiration
 func NewCircuitInformation(expiredAfter time.Duration) CircuitInformation {
 	return CircuitInformation{


### PR DESCRIPTION
While sharing the docs with others I noticed a few places where the comments could be improved to link between things and just fix up some spelling errors.