### PR TITLE
Fix golangci-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v2.0.2
   hooks:
-  - id: golangci-lint
+  - id: golangci-lint-config-verify
+  - id: golangci-lint-full
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Much of the design of this library was informed by github.com/sony/go-breaker.
 The significant differences are as follows:
 
 * Representation of the internal state of the circuit breaker to allow it to
-  be stored/retrieved 
+  be stored/retrieved
 
 * Naming of some constants to make it clearer what they are
 


### PR DESCRIPTION
Use the new hook types that better match what I want from the executions.