### PR TITLE
Start tracking coverage with codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
         run: make ci-show-integration-cov
         env:
           DYNAMODB_URL: http://localhost:8000
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "./coverage.out"
       - name: Require minimum test coverage percentage
         env:
           TESTCOVERAGE_PCT: 98


### PR DESCRIPTION
As much as I dislike the product and the company which owns it, it still seems to be the best option here short of writing something myself